### PR TITLE
fix tests - remove sourcemaps from test controls

### DIFF
--- a/tests/controls/01-at-least.css
+++ b/tests/controls/01-at-least.css
@@ -13,5 +13,3 @@ ul > li:nth-last-child(n+4), ul > li:nth-last-child(n+4) ~ li, nav > div:nth-las
 ul > li:nth-last-child(n+4), ul > li:nth-last-child(n+4) ~ *, nav > div:nth-last-child(n+4), nav > div:nth-last-child(n+4) ~ * {
   test: ok;
 }
-
-/*# sourceMappingURL=01-at-least.css.map */

--- a/tests/controls/02-at-most.css
+++ b/tests/controls/02-at-most.css
@@ -13,5 +13,3 @@ ul > li:nth-last-child(-n+4):first-child, ul > li:nth-last-child(-n+4):first-chi
 ul > li:nth-last-child(-n+4):first-child, ul > li:nth-last-child(-n+4):first-child ~ *, nav > div:nth-last-child(-n+4):first-child, nav > div:nth-last-child(-n+4):first-child ~ * {
   test: ok;
 }
-
-/*# sourceMappingURL=02-at-most.css.map */

--- a/tests/controls/03-between.css
+++ b/tests/controls/03-between.css
@@ -13,5 +13,3 @@ ul > li:nth-last-child(n+4):nth-last-child(-n+6):first-child, ul > li:nth-last-c
 ul > li:nth-last-child(n+4):nth-last-child(-n+6):first-child, ul > li:nth-last-child(n+4):nth-last-child(-n+6):first-child ~ *, nav > div:nth-last-child(n+4):nth-last-child(-n+6):first-child, nav > div:nth-last-child(n+4):nth-last-child(-n+6):first-child ~ * {
   test: ok;
 }
-
-/*# sourceMappingURL=03-between.css.map */


### PR DESCRIPTION
This fixes the tests for me (and with the `Gemfile.lock` removal in #3, should fix the Travis build - see https://travis-ci.org/adjohnson916/quantity-queries/builds/53434451). The test `config.rb` disables sourcemaps, and I can't get the unit test code to produce sourcemaps, so fixing the tests required removing sourcemaps from the control files.
