### PR TITLE
Add package.json for npm with eyeglass metadata.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "quantity-queries",
+  "version": "0.4.0",
+  "description": "Simple quantity queries mixins for Sass",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "rake test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danielguillan/quantity-queries.git"
+  },
+  "keywords": [
+    "sass",
+    "eyeglass-module",
+    "scss",
+    "css",
+    "quantity",
+    "query",
+    "at-least",
+    "at-most",
+    "between",
+    "exactly",
+    "count",
+    "elements"
+  ],
+  "eyeglass": {
+    "sassDir": "stylesheets",
+    "exports": false,
+    "name":    "quantity-queries",
+    "needs":   "*"
+  },
+  "author": "Daniel Guillan <daniel.guillan@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/danielguillan/quantity-queries/issues"
+  },
+  "homepage": "https://github.com/danielguillan/quantity-queries#readme"
+}


### PR DESCRIPTION
Fixes https://github.com/danielguillan/quantity-queries/issues/8 by adding npm package.json with eyeglass metadata.

Please also publish to npm after reviewing + merging this PR 
so this module can be directly installed and used with sass + eyeglass.